### PR TITLE
Add option to disable wrapping arrows and single-slide scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,21 +32,22 @@ Plain CSS Slider with responsive pagination.
 }
 ```
 
+## `$wrap: true`
+Show a left arrow to the last page on the first page and vice versa or not.
+
+```scss
+@include paginate(2, $wrap: false); // No wrapping arrows on first and last slide
+```
+
+## `$scroll-full-page: true`
+Arrows scroll either a full page or a single slide.
+
+```scss
+@include paginate(2, $scroll-full-page: false); // Arrows scroll single slides
+```
+
 ## TODO
 - Arrow right to last page shown in some off-grid cases it shouldn't
-
-## Notes
-
-### Last page overlap
-n: 4, num: 8/7/6/5
-
-```
-o  1,8   0  o  1,7   0    o  1,6   0  o  1,5   0
-|  2,7   1  |  2,6   1    |  2,5   1  |o 2,4 0 1
-|  3,6   2  |  3,5   2    |o 3,4 0 2  || 3,3 1 2
-|  4,5   3  |o 4,4 0 3    || 4,3 1 3  || 4,2 2 3
-o  5,4 0 0   | 5,3 1 0     | 5,2 2 0   | 5,1 3 0
-|  6,3 1 1   | 6,2 2 1     | 6,1 3 1
-|  7,2 2 2   | 7,1 3 2
-|  8,1 3 3
-```
+- Single slide mode sliding last page too far if `input:nth-last-child(-n+#{$n-1}):checked`
+- Mobile swipe script always slides full pages
+- Make `$wrap` and `$scroll-full-page` configurable by setting a class instead of passing params

--- a/sass/_paginate.scss
+++ b/sass/_paginate.scss
@@ -1,4 +1,4 @@
-@mixin paginate($n, $wrap: true) {
+@mixin paginate($n, $wrap: true, $scroll-full-page: true) {
 	> .slides > li {width: 100% / $n}
 
 	> .arrows > label {
@@ -6,12 +6,17 @@
 	}
 
 	> .dots > label {
-		display: none; // Hide all dots by default
+		@if $scroll-full-page { // Show only one dot per page
+			display: none; // Hide all dots
 
-		// Show the dots for each page
-		&:last-of-type, // The last page, the leftmost slide for all other pages (below)
-		&:nth-of-type(#{$n}n-#{$n - 1}):not(:nth-last-of-type(-n+#{$n})) {
-			display: inline;
+			&:last-of-type, // The last page, the leftmost slide for all other pages (below)
+			&:nth-of-type(#{$n}n-#{$n - 1}):not(:nth-last-of-type(-n+#{$n})) {
+				display: inline;
+			}
+		} @else { // Hide dots for non left-most slides on last page
+			&:nth-last-of-type(-n+#{$n - 1}) {
+				display: none;
+			}
 		}
 	}
 	> input:nth-last-of-type(#{$n}):checked ~ .dots > label:last-of-type:before {
@@ -23,20 +28,6 @@
 	@for $i from 0 to $css-slider-max-slides {
 		> input:nth-of-type(#{$i + 1}):checked {
 			//TODO Highlight current dot
-
-			// Left arrow on standard pages
-			@if $i >= $n {
-				~ .arrows:not(.right) > label:nth-of-type(#{($i - $i % $n) - $n + 1}) {
-					display: block;
-				}
-			}
-
-			// Right arrow on standard pages
-			~ .arrows:not(.left) > label:nth-of-type(#{($i - $i % $n) + $n + 1}) {
-				&:not(:nth-last-of-type(-n+#{$n})) {
-					display: block;
-				}
-			}
 
 			@if $wrap {
 				// Left arrow on first page, goes to last slide
@@ -52,32 +43,76 @@
 				}
 			}
 
-			// Right arrow to last page
-			&:nth-last-of-type(n+#{$n + 1}):nth-last-of-type(-n+#{$n * 2}) {
-				~ .arrows:not(.left) > label:last-child {
+			@if $scroll-full-page and $n > 1 {
+				// Left arrow on standard pages
+				@if $i >= $n {
+					~ .arrows:not(.right) > label:nth-of-type(#{($i - $i % $n) - $n + 1}) {
+						display: block;
+					}
+				}
+
+				// Right arrow on standard pages
+				~ .arrows:not(.left) > label:nth-of-type(#{($i - $i % $n) + $n + 1}) {
+					&:not(:nth-last-of-type(-n+#{$n})) {
+						display: block;
+					}
+				}
+
+				// Right arrow to last page
+				&:nth-last-of-type(n+#{$n + 1}):nth-last-of-type(-n+#{$n * 2}) {
+					~ .arrows:not(.left) > label:last-child {
+						display: block;
+					}
+				}
+
+				// Current dot
+				~ .dots > label:nth-of-type(#{$i - $i % $n + 1})::before,
+				&:last-of-type ~ .dots > label:last-of-type::before {
+					opacity: 1;
+				}
+
+				// Slide the slides
+				// For radios on all pages except the last
+				&:not(:nth-last-of-type(-n+#{$n})) {
+					// Slide left by full page-widths
+					~ .slides > li {
+						transform: translate3d(($i - $i % $n) * -100%, 0, 0);
+					}
+				}
+
+				// For each radio on the last page
+				@for $j from 0 to $n { // Nested loop! Keep this short
+					&:nth-last-of-type(#{$n - $j}) {
+						// Slide to the last page
+						~ .slides > li {
+							// Slide #{$i - $j} is always the left-most slide on the last page
+							transform: translate3d(($i - $j) * -100%, 0, 0);
+						}
+					}
+				}
+
+			} @else { // Scroll by only one item
+				// Left arrow
+				@if $i > 0 {
+					~ .arrows:not(.right) > label:nth-of-type(#{$i}) {
+						display: block;
+					}
+				}
+
+				// Right arrow
+				&:not(:nth-last-of-type(-n+#{$n})) ~ .arrows:not(.left) > label:nth-of-type(#{$i + 2}) {
 					display: block;
 				}
-			}
 
-			// For radios on all pages except the last
-			&:not(:nth-last-of-type(-n+#{$n})) {
-				// Slide left by full page-widths
-				~ .slides > li {
-					transform: translate3d(($i - $i % $n) * -100%, 0, 0);
+				// Current dot
+				~ .dots label:nth-of-type(#{$i + 1 })::before {
+					opacity: 1;
 				}
-			}
-			~ .dots label:nth-of-type(#{$i + 1 }):before {
-				opacity: 1;
-			}
 
-			// For each radio on the last page
-			@for $j from 0 to $n { // Nested loop! Keep this short
-				&:nth-last-of-type(#{$n - $j}) {
-					// Slide to the last page
-					~ .slides > li {
-						// Slide #{$i - $j} is always the left-most slide on the last page
-						transform: translate3d(($i - $j) * -100%, 0, 0);
-					}
+				// Slide the slides
+				// FIXME Do not slide the last page further left if one of the last $n - 1 radios is checked
+				~ .slides > li {
+					transform: translate3d($i * -100%, 0, 0);
 				}
 			}
 		}


### PR DESCRIPTION
Should be fully backwards compatible, thanks to default values.
